### PR TITLE
Fix light mode enum order

### DIFF
--- a/src/lightcontrol/client/messages/LightModes.hpp
+++ b/src/lightcontrol/client/messages/LightModes.hpp
@@ -2,8 +2,8 @@
 
 namespace LightControl {
 	enum class LightMode {
-		ON,
 		OFF,
+		ON,
 		STROBE,
 		GLITTER,
 		FREQUENCY_PANEL,


### PR DESCRIPTION
OFF and ON was swapped in the light mode enum.
Swap them back so the correct mode is set when they are used.